### PR TITLE
Update types to be publicly accessible

### DIFF
--- a/lib/xml_stream.ex
+++ b/lib/xml_stream.ex
@@ -31,8 +31,8 @@ defmodule XmlStream do
   Could be either `Keyword` or `map`. Order of the attributes are
   preserved in case of `Keyword`
   """
-  @type attrs :: map | Keyword.t()
-  @opaque fragment :: [tuple | fragment]
+  @type attrs :: map | Keyword.t() | [{:binary, :binary}]
+  @type fragment :: [tuple | fragment]
 
   @typedoc """
   The elements of `Enumerable` should be of type `t:fragment/0`


### PR DESCRIPTION
I have been finding that dialyzer is really unhappy with any code I write attempting to use XmlStream, because there is no way to construct an arbitrary XML fragment and the type is declared to be opaque.

``` elixir
defmodule MyFile do
  def file do
    [
      XmlStream.declaration(),
      XmlStream.empty_element("Type", %{})
    ]
    |> XmlStream.stream!(printer: XmlStream.Printer.Ugly)
  end
end
```

```
Function call without opaqueness type mismatch.

Call does not have expected opaque term of type XmlStream.fragment() in the 1st position.

MyFile.file(
  [XmlStream.fragment(), ...],
  <<91, 67, 111, 110, 116, 101, 110, 116, 95, 84, 121, 112, 101, 115, 93, 46, 120, 109,
    108>>
)
```

I'm also finding that I'd like to inject attributes without introducing hundreds of new atoms. I could do this with maps, but though it might be nice to retain order by passing in lists of tuples.