### PR TITLE
Fix spec for attrs() to allow lists of tuples

### DIFF
--- a/lib/xml_stream.ex
+++ b/lib/xml_stream.ex
@@ -31,7 +31,7 @@ defmodule XmlStream do
   Could be either `Keyword` or `map`. Order of the attributes are
   preserved in case of `Keyword`
   """
-  @type attrs :: map | Keyword.t() | [{:binary, :binary}]
+  @type attrs :: map | Keyword.t() | [{binary(), binary()}]
   @type fragment :: [tuple | fragment]
 
   @typedoc """


### PR DESCRIPTION
`[{:binary, :binary}]` only matches on the atom `:binary`, rather than on the type `binary()`.